### PR TITLE
Fix FT debugger events subscription.

### DIFF
--- a/packages/function-tree/src/devtools/index.js
+++ b/packages/function-tree/src/devtools/index.js
@@ -56,10 +56,9 @@ class DevtoolsClass {
   }
   init () {
     this.addListeners()
-
+    this.trees.forEach(this.watchExecution)
     this.ws.onopen = () => {
       this.ws.send(JSON.stringify({type: 'ping'}))
-      this.trees.forEach(this.watchExecution)
     }
     this.ws.onclose = () => {
       console.warn('Debugger application is not running on selected port... will reconnect automatically behind the scenes')


### PR DESCRIPTION
Current implementation having an issue with debugger events subscription. Debugger subscribes on tree events only after opening web socket connection, so the first tree events not processed (for example 'start' tree event). It prevents the debugger app to show tree execution at all.